### PR TITLE
Restrict image widths to window size

### DIFF
--- a/source/stylesheets/all.css.erb
+++ b/source/stylesheets/all.css.erb
@@ -3,6 +3,10 @@ body {
     padding: 20px 0px 20px 0px;
 }
 
+img {
+    max-width: 100%;
+}
+
 .content {
     padding: 10px 30px 20px 30px;
     background-color: #FFFFFF;


### PR DESCRIPTION
Currently, some images (e.g. the title on the top page) are wider than
the screen on small devices such as smartphones.
