### PR TITLE
Add wercker build status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 http://m3dev.github.io/
 
+[![wercker status](https://app.wercker.com/status/c00563e4b57ab0026904909b2752455c/s "wercker status")](https://app.wercker.com/project/bykey/c00563e4b57ab0026904909b2752455c)
+
+
 ### このサイトの運用について
 
 typo の修正やコンテンツの追加は以下のようにして行ってください。


### PR DESCRIPTION
Now the badge only adds a friendly link to the Wercker page for us. However, we can add JavaScript syntax check and such to Wercker build later, and then this badge will shine.
